### PR TITLE
알림 서버를 추가한 compose 파일

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,19 @@ services:
       - ./nginx/log:/var/log/nginx
     networks:
       - app-net
+  redis:
+    image: redis
+    networks:
+      - app-net
+  notification:
+    image: laterality/caffeine-notification:1577067797
+    depends_on:
+    - redis
+    environment:
+    - REDIS_HOST=redis:6379
+    - AUTH_HEADER=<AUTH_HEADER_HERE>
+    networks:
+    - app-net
 
 networks:
   app-net:


### PR DESCRIPTION
`notification` 서비스의 `AUTH_HEADER` 환경변수는 시크릿 값이라 배포 환경에서 별도로 세팅해야 합니다.